### PR TITLE
Add json_schema_extra merging for PocketBase fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The collection name will be automatically derived from the class name (pluralize
 - JSON: `List`, `Dict`
 - File: `FileUploadORM`
   - You can set a maximum file size limit using `Field(json_schema_extra={"maxSize": 5242880})` (size in bytes)
+- Additional PocketBase field options can be provided for any field using `Field(..., json_schema_extra={...})`. These options are merged into the collection schema during `sync_collection`.
 - Relation: `Union[RelatedModel, str]`
 - Select: `Enum`
 

--- a/pocketbase_orm.py
+++ b/pocketbase_orm.py
@@ -495,21 +495,15 @@ class PBModel(BaseModel):
                     logger.error(f"No valid related model found for field {name}")
                     raise ValueError(f"Invalid relation configuration for field {name}")
 
-            if field_def["type"] == "file":
-                # Check if there's a maxSize parameter in the field info
-                max_size = None
-                if (
-                    hasattr(field_info, "json_schema_extra")
-                    and field_info.json_schema_extra
-                ):
-                    max_size = field_info.json_schema_extra.get("maxSize")
-
-                # Set options if maxSize is provided
-                if max_size is not None:
-                    field_def["maxSize"] = max_size
-                    logger.debug(
-                        f"Configured file field {name} with maxSize: {max_size}"
-                    )
+            # Merge additional options defined via json_schema_extra
+            if (
+                hasattr(field_info, "json_schema_extra")
+                and field_info.json_schema_extra
+            ):
+                field_def.update(field_info.json_schema_extra)
+                logger.debug(
+                    f"Merged json_schema_extra for {name}: {field_info.json_schema_extra}"
+                )
 
             fields.append(field_def)
             logger.debug(f"Added field definition: {field_def}")

--- a/tests/test_json_schema_extra_generic.py
+++ b/tests/test_json_schema_extra_generic.py
@@ -19,7 +19,7 @@ async def setup_extra_model(pb_client):
 
 @pytest.mark.asyncio
 async def test_json_schema_extra_applied(setup_extra_model):
-    collection = await ExtraModel._pb_client.collections.get_one("extra_models")
+    collection = await ExtraModel._pb_client.collections.get_one("extra_models")  # type: ignore
     fields = collection["fields"]
     name_field = next((f for f in fields if f["name"] == "name"), None)
     assert name_field is not None

--- a/tests/test_json_schema_extra_generic.py
+++ b/tests/test_json_schema_extra_generic.py
@@ -1,0 +1,26 @@
+import pytest
+import pytest_asyncio
+from pydantic import Field
+
+from pocketbase_orm import PBModel
+
+
+class ExtraModel(PBModel, collection="extra_models"):
+    name: str | None = Field(default=None, json_schema_extra={"min": 2})
+
+
+@pytest_asyncio.fixture(scope="function")
+async def setup_extra_model(pb_client):
+    PBModel.bind_client(pb_client)
+    await ExtraModel.sync_collection()
+    yield
+    await ExtraModel.delete_collection()
+
+
+@pytest.mark.asyncio
+async def test_json_schema_extra_applied(setup_extra_model):
+    collection = await ExtraModel._pb_client.collections.get_one("extra_models")
+    fields = collection["fields"]
+    name_field = next((f for f in fields if f["name"] == "name"), None)
+    assert name_field is not None
+    assert name_field.get("min") == 2


### PR DESCRIPTION
## Summary
- merge `json_schema_extra` on all fields when syncing collection schemas
- document custom field options in README
- test applying `json_schema_extra` for non-file fields

## Testing
- `just check` *(fails: ty could not resolve imports)*
- `just test` *(fails: ReadTimeout during test_create_example_with_file)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac7a6634832eb008825322958b6b