### PR TITLE
Add PBReference list and optional support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Python ORM (Object-Relational Mapper) for PocketBase that provides Pydantic mo
 - 🚀 Pydantic model integration for data validation and serialization
 - 🔄 Automatic schema synchronization with PocketBase collections
 - 📦 Support for most PocketBase field types including relations and file uploads
+- 🔗 Reference fields support single, optional, and list relations using `PBReference`
 - 🛠️ Simple and intuitive API for CRUD operations
 
 ## Installation

--- a/pocketbase_orm.py
+++ b/pocketbase_orm.py
@@ -436,20 +436,31 @@ class PBModel(BaseModel):
             # Add additional configuration for relation fields
             if field_def["type"] == "relation":
                 logger.debug(f"Configuring relation field {name}")
-                # Find the related model in Union types
                 related_model = None
-                if hasattr(field, "__origin__") and cls.is_union_type(field):
-                    for arg in field.__args__:
-                        if arg is str:
-                            continue
-                        if cls._is_reference_type(arg):
-                            releated_model = cls.get_referenced_pbmodel_type(arg)
-                            if releated_model:
-                                related_model = releated_model
-                                logger.debug(
-                                    f"Found related model for {name}: {related_model}"
+                max_select = 1
+                if hasattr(field, "__origin__"):
+                    if cls.is_union_type(field):
+                        for arg in field.__args__:
+                            if arg is str:
+                                continue
+                            if cls._is_reference_list(arg):
+                                related_model = cls.get_referenced_pbmodel_type(
+                                    get_args(arg)[0]
                                 )
-                            break
+                                max_select = 0
+                                break
+                            if cls._is_reference_type(arg):
+                                related_model = cls.get_referenced_pbmodel_type(arg)
+                                max_select = 1
+                                break
+                    elif cls._is_reference_list(field):
+                        related_model = cls.get_referenced_pbmodel_type(
+                            get_args(field)[0]
+                        )
+                        max_select = 0
+                    elif cls._is_reference_type(field):
+                        related_model = cls.get_referenced_pbmodel_type(field)
+                        max_select = 1
                 if related_model:
                     try:
                         logger.debug(
@@ -469,7 +480,7 @@ class PBModel(BaseModel):
                                 "presentable": False,
                                 "cascadeDelete": False,
                                 "minSelect": 0,
-                                "maxSelect": 1,
+                                "maxSelect": max_select,
                                 "collectionId": collection[
                                     "id"
                                 ],  # This must be present and non-empty
@@ -524,6 +535,16 @@ class PBModel(BaseModel):
             return True
         return False
 
+    @staticmethod
+    def _is_reference_list(field_type: type) -> bool:
+        """Check if a type is a list of PBReferenceType."""
+        origin = get_origin(field_type)
+        if origin is list:
+            inner_args = get_args(field_type)
+            if inner_args and PBModel._is_reference_type(inner_args[0]):
+                return True
+        return False
+
     @classmethod
     def _get_field_type(cls, pydantic_field: Any) -> str:
         """
@@ -532,7 +553,12 @@ class PBModel(BaseModel):
         # Get all possible types to check
         types_to_check = []
         if hasattr(pydantic_field, "__origin__"):
+            if cls._is_reference_list(pydantic_field):
+                return "relation"
             if cls.is_union_type(pydantic_field):
+                for arg in pydantic_field.__args__:
+                    if cls._is_reference_list(arg) or cls._is_reference_type(arg):
+                        return "relation"
                 types_to_check.extend(pydantic_field.__args__)
             elif pydantic_field.__origin__ is list:
                 return "json"

--- a/tests/test_reference_variants.py
+++ b/tests/test_reference_variants.py
@@ -1,0 +1,66 @@
+import uuid
+import pytest
+import pytest_asyncio
+from pocketbase_orm import PBModel, PBReference, User
+
+
+class SingleOptional(PBModel, collection="single_optional"):
+    name: str
+    user: PBReference[User] | None = None
+
+
+class MultiRef(PBModel, collection="multi_ref"):
+    name: str
+    users: list[PBReference[User]]
+
+
+class MultiOptional(PBModel, collection="multi_optional"):
+    name: str
+    users: list[PBReference[User]] | None = None
+
+
+@pytest_asyncio.fixture(scope="function")
+async def setup_reference_models(pb_client):
+    PBModel.bind_client(pb_client)
+    await SingleOptional.sync_collection()
+    await MultiRef.sync_collection()
+    await MultiOptional.sync_collection()
+    yield
+    await SingleOptional.delete_collection()
+    await MultiRef.delete_collection()
+    await MultiOptional.delete_collection()
+
+
+@pytest.mark.asyncio
+async def test_reference_types(setup_reference_models, pb_client):
+    user = await User(
+        email=f"test.{uuid.uuid4()}@example.com",
+        password="password123",
+        passwordConfirm="password123",
+        name="Tester",
+    ).save()
+
+    single = SingleOptional(name="s", user=user.id)
+    await single.save()
+    retrieved_single = await SingleOptional.get_one(single.id)  # type: ignore
+    assert retrieved_single.user == user.id
+
+    multi = MultiRef(name="m", users=[user.id])
+    await multi.save()
+    retrieved_multi = await MultiRef.get_one(multi.id)  # type: ignore
+    assert retrieved_multi.users == [user.id]
+
+    multi_opt = MultiOptional(name="o", users=[user.id])
+    await multi_opt.save()
+    retrieved_multi_opt = await MultiOptional.get_one(multi_opt.id)  # type: ignore
+    assert retrieved_multi_opt.users == [user.id]
+
+    col = await pb_client.collections.get_one("multi_ref")
+    field = next(f for f in col["fields"] if f["name"] == "users")
+    assert field.get("maxSelect", 0) == 0
+
+    col_single = await pb_client.collections.get_one("single_optional")
+    field_single = next(f for f in col_single["fields"] if f["name"] == "user")
+    assert field_single.get("maxSelect", 1) == 1
+
+    await user.delete()


### PR DESCRIPTION
## Summary
- support list of PBReference and optional reference fields
- document reference field variations
- test single optional reference and lists of references

## Testing
- `just check`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6851ace02688832e99f4aec24a3787ee