### PR TITLE
Add optional enum list support

### DIFF
--- a/pocketbase_orm.py
+++ b/pocketbase_orm.py
@@ -416,20 +416,29 @@ class PBModel(BaseModel):
 
             # Configure enum select field options if applicable
             let_enum = None
-            if hasattr(field, "__origin__") and cls.is_union_type(field):
-                for arg in field.__args__:
-                    if isinstance(arg, type) and issubclass(arg, Enum):
+            max_select = 1
+            if cls.is_union_type(field):
+                for arg in get_args(field):
+                    if getattr(arg, "__origin__", None) is list:
+                        inner = get_args(arg)[0]
+                        if isinstance(inner, type) and issubclass(inner, Enum):
+                            let_enum = inner
+                            max_select = len(list(let_enum))
+                            break
+                    elif isinstance(arg, type) and issubclass(arg, Enum):
                         let_enum = arg
                         break
+            elif getattr(field, "__origin__", None) is list:
+                inner = get_args(field)[0]
+                if isinstance(inner, type) and issubclass(inner, Enum):
+                    let_enum = inner
+                    max_select = len(list(let_enum))
             elif isinstance(field, type) and issubclass(field, Enum):
                 let_enum = field
 
             if let_enum is not None and field_def["type"] == "select":
                 field_def.update(
-                    {
-                        "maxSelect": 1,
-                        "values": [e.value for e in let_enum],
-                    }
+                    {"maxSelect": max_select, "values": [e.value for e in let_enum]}
                 )
                 logger.debug(f"Configured enum select field {name} with: {field_def}")
 
@@ -535,6 +544,9 @@ class PBModel(BaseModel):
             if cls.is_union_type(pydantic_field):
                 types_to_check.extend(pydantic_field.__args__)
             elif pydantic_field.__origin__ is list:
+                item_type = pydantic_field.__args__[0]
+                if PBModel._is_enum_type(item_type):
+                    return "select"
                 return "json"
         elif hasattr(pydantic_field, "__or__") and hasattr(pydantic_field, "__args__"):
             types_to_check.extend(pydantic_field.__args__)
@@ -543,6 +555,12 @@ class PBModel(BaseModel):
 
         # Check all types in priority order
         for field_type in types_to_check:
+            origin = get_origin(field_type)
+            if origin is list:
+                item_type = get_args(field_type)[0]
+                if PBModel._is_enum_type(item_type):
+                    return "select"
+                return "json"
             # Special types
             if PBModel._is_enum_type(field_type):
                 return "select"

--- a/tests/test_pocketbase_orm.py
+++ b/tests/test_pocketbase_orm.py
@@ -54,6 +54,21 @@ class ModelWithEnum(PBModel, collection="enum_models"):
     user_type: UserType  # Using the actual enum type
 
 
+class OptionalEnumModel(PBModel, collection="optional_enum_models"):
+    name: str
+    user_type: UserType | None = None
+
+
+class ListEnumModel(PBModel, collection="list_enum_models"):
+    name: str
+    user_types: list[UserType]
+
+
+class OptionalListEnumModel(PBModel, collection="optional_list_enum_models"):
+    name: str
+    user_types: list[UserType] | None = None
+
+
 @pytest_asyncio.fixture(scope="function")
 async def setup_models(pb_client):
     """Fixture to bind the client and sync collections."""
@@ -61,10 +76,16 @@ async def setup_models(pb_client):
     await RelatedModel.sync_collection()
     await Example.sync_collection()
     await ModelWithEnum.sync_collection()
+    await OptionalEnumModel.sync_collection()
+    await ListEnumModel.sync_collection()
+    await OptionalListEnumModel.sync_collection()
     await NonTypeChecksModel.sync_collection()
     await JSONTypeandFile.sync_collection()
     yield
     await ModelWithEnum.delete_collection()
+    await OptionalEnumModel.delete_collection()
+    await ListEnumModel.delete_collection()
+    await OptionalListEnumModel.delete_collection()
     await Example.delete_collection()
     await RelatedModel.delete_collection()
     await NonTypeChecksModel.delete_collection()
@@ -390,6 +411,47 @@ async def test_enum_field_handling(setup_models):
     retrieved2 = await ModelWithEnum.get_one(instance2_id)
     assert retrieved2.user_type == UserType.GUEST
     assert isinstance(retrieved2.user_type, UserType)
+
+
+@pytest.mark.asyncio
+async def test_optional_and_list_enums(setup_models):
+    """Ensure optional and list enums are handled correctly."""
+    opt = await OptionalEnumModel(name="Opt", user_type=UserType.REGULAR).save()
+    fetched_opt = await OptionalEnumModel.get_one(opt.id)  # type: ignore
+    assert fetched_opt.user_type == UserType.REGULAR
+    opt_collection = await opt._pb_client.collections.get_one("optional_enum_models")
+    opt_field = next(f for f in opt_collection["fields"] if f["name"] == "user_type")
+    assert opt_field["maxSelect"] == 1
+    assert opt_field["required"] is False
+
+    list_model = await ListEnumModel(
+        name="List", user_types=[UserType.ADMIN, UserType.GUEST]
+    ).save()
+    fetched_list = await ListEnumModel.get_one(list_model.id)  # type: ignore
+    assert fetched_list.user_types == [UserType.ADMIN, UserType.GUEST]
+
+    collection = await list_model._pb_client.collections.get_one("list_enum_models")
+    field = next(f for f in collection["fields"] if f["name"] == "user_types")
+    assert field["type"] == "select"
+    assert field["maxSelect"] == len(UserType)
+
+
+@pytest.mark.asyncio
+async def test_optional_list_enum_model(setup_models):
+    """Ensure optional list of enums works."""
+    model = await OptionalListEnumModel(name="OptListNone").save()
+    fetched = await OptionalListEnumModel.get_one(model.id)  # type: ignore
+    assert fetched.user_types == []
+    collection = await model._pb_client.collections.get_one("optional_list_enum_models")
+    field = next(f for f in collection["fields"] if f["name"] == "user_types")
+    assert field["required"] is False
+    assert field["maxSelect"] == len(UserType)
+
+    model2 = await OptionalListEnumModel(
+        name="OptListVal", user_types=[UserType.REGULAR]
+    ).save()
+    fetched2 = await OptionalListEnumModel.get_one(model2.id)  # type: ignore
+    assert fetched2.user_types == [UserType.REGULAR]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add OptionalListEnumModel fixture and CRUD test
- detect list-of-enum types inside unions

## Testing
- `just check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_6851ad159ae8832e82bd254dfdaace96